### PR TITLE
feat: Make font control bar collapsible

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,6 +231,7 @@ $$
 
         const FONT_CONTROL_UI_HTML = `
         <div id="font-controls" style="position: fixed; top: 10px; right: 10px; background: rgba(240,240,240,0.95); padding: 8px; border-radius: 5px; box-shadow: 0 2px 5px rgba(0,0,0,0.2); z-index: 1000; display: flex; align-items: center; gap: 5px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; font-size: 13px;">
+            <button id="toggleCollapseBtn" title="Toggle font controls" style="padding: 4px 8px; cursor: pointer; border: 1px solid #ccc; background-color: #fff; color: black; border-radius: 3px; margin-right: 5px;">Toggle</button>
             <button id="decreaseFontBtn" title="Decrease font size" style="padding: 4px 8px; cursor: pointer; border: 1px solid #ccc; background-color: #fff; color: black; border-radius: 3px;">-</button>
             <span id="currentFontSizeDisplay" style="min-width: 40px; text-align: center; padding: 0 5px; color: black;">100%</span>
             <button id="increaseFontBtn" title="Increase font size" style="padding: 4px 8px; cursor: pointer; border: 1px solid #ccc; background-color: #fff; color: black; border-radius: 3px;">+</button>
@@ -273,6 +274,45 @@ $$
             resetButton.addEventListener('click', () => applyFontSize(DEFAULT_PERCENT));
             
             applyFontSize(currentPercent); // Apply initial font size
+        }
+        `;
+
+        const COLLAPSIBLE_CONTROLS_SCRIPT_LOGIC = `
+        function setupCollapsibleControls() {
+            const toggleButton = document.getElementById('toggleCollapseBtn');
+            const controlsToToggle = [
+                document.getElementById('decreaseFontBtn'),
+                document.getElementById('currentFontSizeDisplay'),
+                document.getElementById('increaseFontBtn'),
+                document.getElementById('resetFontBtn'),
+                document.getElementById('toggleThemeBtn')
+            ].filter(el => el !== null); // Filter out nulls if some elements are not found
+
+            if (!toggleButton || controlsToToggle.length < 4) { // Check if main button and at least some controls exist
+                console.error("Collapsible control elements not found. Ensure IDs are correct ('toggleCollapseBtn', etc.) and DOM is ready.");
+                if (toggleButton) toggleButton.style.display = 'none'; // Hide toggle if other controls are missing
+                return;
+            }
+
+            const LS_COLLAPSED_KEY = 'fontControlsCollapsed';
+
+            function applyCollapsedState(collapsed) {
+                const isCurrentlyCollapsed = typeof collapsed === 'boolean' ? collapsed : JSON.parse(localStorage.getItem(LS_COLLAPSED_KEY) || 'true');
+
+                controlsToToggle.forEach(control => {
+                    control.style.display = isCurrentlyCollapsed ? 'none' : ''; // Use '' to revert to default/CSS display
+                });
+                toggleButton.textContent = isCurrentlyCollapsed ? 'Expand Controls' : 'Collapse Controls';
+                localStorage.setItem(LS_COLLAPSED_KEY, JSON.stringify(isCurrentlyCollapsed));
+            }
+
+            toggleButton.addEventListener('click', () => {
+                const currentState = JSON.parse(localStorage.getItem(LS_COLLAPSED_KEY) || 'true');
+                applyCollapsedState(!currentState);
+            });
+
+            // Initial state application
+            applyCollapsedState(); // Applies based on localStorage or default true
         }
         `;
 
@@ -395,6 +435,7 @@ $$
                             ${KATEX_INIT_LOGIC}
                             ${FONT_SIZE_CONTROL_SCRIPT_LOGIC}
                             ${THEME_CONTROL_SCRIPT_LOGIC}
+                            ${COLLAPSIBLE_CONTROLS_SCRIPT_LOGIC}
                         <\/script>
                         <script defer src="${KATEX_JS_LINK}"><\/script>
                         <script defer src="${KATEX_AUTORENDER_JS_LINK}" onload="initKatexAutoRender()"><\/script>
@@ -406,6 +447,7 @@ $$
                             document.addEventListener('DOMContentLoaded', () => {
                                 setupFontSizeControls();
                                 setupThemeControls();
+                                setupCollapsibleControls();
                                 // initKatexAutoRender is called by KaTeX auto-render script's onload.
                             });
                         <\/script>


### PR DESCRIPTION
The font control bar in the rendered output tab is now collapsible. It will be contracted by default.

Key changes:
- Added a toggle button to the font control bar.
- Implemented JavaScript logic to show/hide the font controls.
- Persisted the collapsed/expanded state in localStorage.
- Ensured the bar is collapsed by default on first load or when no state is saved.