### PR TITLE
Add PDF export functionality to rendered output

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,6 +237,7 @@ $$
             <button id="increaseFontBtn" title="Increase font size" style="padding: 4px 8px; cursor: pointer; border: 1px solid #ccc; background-color: #fff; color: black; border-radius: 3px;">+</button>
             <button id="resetFontBtn" title="Reset font size" style="padding: 4px 8px; cursor: pointer; margin-left: 5px; border: 1px solid #ccc; background-color: #fff; color: black; border-radius: 3px;">Reset</button>
             <button id="toggleThemeBtn" title="Toggle theme" style="padding: 4px 8px; cursor: pointer; margin-left: 5px; border: 1px solid #ccc; background-color: #fff; color: black; border-radius: 3px;">Theme</button>
+            <button id="saveAsPdfBtn" title="Save as PDF" style="padding: 4px 8px; cursor: pointer; margin-left: 5px; border: 1px solid #ccc; background-color: #fff; color: black; border-radius: 3px;">Save PDF</button>
         </div>
         `;
 
@@ -313,6 +314,63 @@ $$
 
             // Initial state application
             applyCollapsedState(); // Applies based on localStorage or default true
+        }
+        `;
+
+        const PDF_GENERATION_SCRIPT_LOGIC = `
+        function setupPdfButton() {
+            const savePdfButton = document.getElementById('saveAsPdfBtn');
+            const renderedBody = document.body; // or document.querySelector('body.markdown-body') for more specificity
+
+            if (!savePdfButton) {
+                console.error("Save PDF button ('saveAsPdfBtn') not found.");
+                return;
+            }
+            if (!renderedBody) {
+                console.error("Rendered body element not found for PDF generation.");
+                return;
+            }
+            if (typeof html2pdf === 'undefined') {
+                console.error("html2pdf.js is not loaded.");
+                savePdfButton.textContent = 'Error: PDF lib missing';
+                savePdfButton.disabled = true;
+                return;
+            }
+
+            savePdfButton.addEventListener('click', () => {
+                console.log("Save as PDF button clicked. Generating PDF...");
+                const options = {
+                    margin:       10, // mm
+                    filename:     'rendered_output.pdf',
+                    image:        { type: 'jpeg', quality: 0.98 },
+                    html2canvas:  { scale: 2, useCORS: true, logging: true, letterRendering: true }, // Added letterRendering
+                    jsPDF:        { unit: 'mm', format: 'a4', orientation: 'portrait' },
+                    pagebreak:    { mode: ['avoid-all', 'css', 'legacy'] } // Added pagebreak options
+                };
+                // Select the main content area to be converted to PDF
+                const elementToPrint = document.querySelector('body.markdown-body');
+
+                // Temporarily remove the controls from the print view
+                const controls = document.getElementById('font-controls');
+                let controlsVisible = false;
+                if (controls) {
+                    controlsVisible = controls.style.display !== 'none';
+                    controls.style.display = 'none';
+                }
+
+                html2pdf().from(elementToPrint).set(options).save().then(() => {
+                    console.log("PDF generation complete.");
+                    // Restore controls if they were visible
+                    if (controls && controlsVisible) {
+                        controls.style.display = ''; // Revert to original display style
+                    }
+                }).catch(err => {
+                    console.error("Error during PDF generation:", err);
+                    if (controls && controlsVisible) {
+                        controls.style.display = ''; // Revert to original display style in case of error
+                    }
+                });
+            });
         }
         `;
 
@@ -431,11 +489,13 @@ $$
                         <link rel="stylesheet" href="${GITHUB_MARKDOWN_CSS_LINK}">
                         <link rel="stylesheet" href="${KATEX_CSS_LINK}">
                         ${RENDERED_PAGE_BODY_STYLE}
+                        <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js" integrity="sha512-GsLlZN/3F2ErC5ifS5QtgpiJtWd43JWSuIgh7mbzZ8zBps+dvLusV+eNQATqgA/HdeKFVgA5v3S/cIrLF7QnIg==" crossorigin="anonymous" referrerpolicy="no-referrer"><\/script>
                         <script>
                             ${KATEX_INIT_LOGIC}
                             ${FONT_SIZE_CONTROL_SCRIPT_LOGIC}
                             ${THEME_CONTROL_SCRIPT_LOGIC}
                             ${COLLAPSIBLE_CONTROLS_SCRIPT_LOGIC}
+                            ${PDF_GENERATION_SCRIPT_LOGIC}
                         <\/script>
                         <script defer src="${KATEX_JS_LINK}"><\/script>
                         <script defer src="${KATEX_AUTORENDER_JS_LINK}" onload="initKatexAutoRender()"><\/script>
@@ -448,6 +508,7 @@ $$
                                 setupFontSizeControls();
                                 setupThemeControls();
                                 setupCollapsibleControls();
+                                setupPdfButton(); // Add this line
                                 // initKatexAutoRender is called by KaTeX auto-render script's onload.
                             });
                         <\/script>


### PR DESCRIPTION
This commit introduces the ability to save the rendered Markdown and LaTeX output as a PDF file.

Key changes:
- Added a "Save PDF" button to the control panel on the rendered output page.
- Integrated the html2pdf.js library (v0.10.1) from a CDN to handle HTML-to-PDF conversion.
- Implemented JavaScript logic (`setupPdfButton`) to:
    - Initialize the "Save PDF" button.
    - Use html2pdf.js to capture the content of `body.markdown-body`.
    - Configure PDF options (filename, margins, image quality, etc.).
    - Temporarily hide the on-page controls (font, theme, PDF button) during PDF generation to ensure a clean output.
    - Initiate the download of the generated PDF.
- The KaTeX-rendered mathematical equations and Markdown styling are preserved in the PDF.