### PR TITLE
Add option to save rendered output as an image

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,6 +76,7 @@
         }
     </style>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 </head>
 <body>
     <div class="container">
@@ -237,6 +238,7 @@ $$
             <button id="increaseFontBtn" title="Increase font size" style="padding: 4px 8px; cursor: pointer; border: 1px solid #ccc; background-color: #fff; color: black; border-radius: 3px;">+</button>
             <button id="resetFontBtn" title="Reset font size" style="padding: 4px 8px; cursor: pointer; margin-left: 5px; border: 1px solid #ccc; background-color: #fff; color: black; border-radius: 3px;">Reset</button>
             <button id="toggleThemeBtn" title="Toggle theme" style="padding: 4px 8px; cursor: pointer; margin-left: 5px; border: 1px solid #ccc; background-color: #fff; color: black; border-radius: 3px;">Theme</button>
+            <button id="saveOutputBtn" title="Save as Image" style="padding: 4px 8px; cursor: pointer; margin-left: 5px; border: 1px solid #ccc; background-color: #fff; color: black; border-radius: 3px;">Save Image</button>
         </div>
         `;
 
@@ -278,6 +280,54 @@ $$
         `;
 
         const COLLAPSIBLE_CONTROLS_SCRIPT_LOGIC = `
+        async function saveOutputAsImage() {
+            console.log("Save image button clicked in new tab");
+            const captureTarget = document.querySelector('body.markdown-body');
+            if (!captureTarget) {
+                console.error('Could not find body.markdown-body to capture.');
+                alert('Error: Could not find content to capture.');
+                return;
+            }
+
+            // Explicitly render KaTeX before capture
+            if (typeof renderMathInElement === 'function') {
+                console.log('Explicitly calling renderMathInElement before capture...');
+                renderMathInElement(captureTarget, {
+                    delimiters: [
+                        {left: "$$", right: "$$", display: true},
+                        {left: "\\[", right: "\\]", display: true},
+                        {left: "$", right: "$", display: false, throwOnError: false},
+                        {left: "\\(", right: "\\)", display: false}
+                    ],
+                    throwOnError: false
+                });
+                console.log('Finished explicit renderMathInElement call.');
+            } else {
+                console.error('renderMathInElement is not available to be called explicitly.');
+            }
+
+            console.log('Waiting with setTimeout before html2canvas...');
+            setTimeout(() => {
+                console.log('Calling html2canvas...');
+                html2canvas(captureTarget, {
+                    useCORS: true,
+                    allowTaint: true,
+                    backgroundColor: '#ffffff', // Explicit background for canvas
+                    logging: true // Enable html2canvas logging
+                })
+                .then(canvas => {
+                    const downloadLink = document.createElement('a');
+                    downloadLink.href = canvas.toDataURL('image/png');
+                    downloadLink.download = 'rendered_output.png';
+                    downloadLink.click();
+                })
+                .catch(error => {
+                    console.error('Error generating image with html2canvas:', error);
+                    alert('Sorry, an error occurred while generating the image.');
+                });
+            }, 500); // 500ms delay
+        }
+
         function setupCollapsibleControls() {
             const toggleButton = document.getElementById('toggleCollapseBtn');
             const controlsToToggle = [
@@ -285,10 +335,11 @@ $$
                 document.getElementById('currentFontSizeDisplay'),
                 document.getElementById('increaseFontBtn'),
                 document.getElementById('resetFontBtn'),
-                document.getElementById('toggleThemeBtn')
+                document.getElementById('toggleThemeBtn'),
+                document.getElementById('saveOutputBtn') // Added save button
             ].filter(el => el !== null); // Filter out nulls if some elements are not found
 
-            if (!toggleButton || controlsToToggle.length < 4) { // Check if main button and at least some controls exist
+            if (!toggleButton || controlsToToggle.length < 5) { // Check if main button and at least some controls exist (updated count)
                 console.error("Collapsible control elements not found. Ensure IDs are correct ('toggleCollapseBtn', etc.) and DOM is ready.");
                 if (toggleButton) toggleButton.style.display = 'none'; // Hide toggle if other controls are missing
                 return;
@@ -313,6 +364,13 @@ $$
 
             // Initial state application
             applyCollapsedState(); // Applies based on localStorage or default true
+
+            const saveImageButton = document.getElementById('saveOutputBtn');
+            if (saveImageButton) {
+                saveImageButton.addEventListener('click', saveOutputAsImage);
+            } else {
+                console.error("Save Output button ('saveOutputBtn') not found in new tab for event listener attachment.");
+            }
         }
         `;
 
@@ -431,6 +489,7 @@ $$
                         <link rel="stylesheet" href="${GITHUB_MARKDOWN_CSS_LINK}">
                         <link rel="stylesheet" href="${KATEX_CSS_LINK}">
                         ${RENDERED_PAGE_BODY_STYLE}
+                        <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"><\/script>
                         <script>
                             ${KATEX_INIT_LOGIC}
                             ${FONT_SIZE_CONTROL_SCRIPT_LOGIC}
@@ -469,6 +528,9 @@ $$
             const htmlWithPreservedKatex = preprocessMarkdownForKatex(markdownText);
             openInNewTab(htmlWithPreservedKatex, "Rendered Markdown & LaTeX");
         });
+
+        // Old saveAsImage function and its listener are removed.
+        // The new saveOutputAsImage function is now defined within the new tab's context.
     </script>
 </body>
 </html>


### PR DESCRIPTION
This commit introduces the ability for you to save the rendered Markdown and LaTeX output as a PNG image.

Key changes:
- Added html2canvas.js library to capture the DOM element as an image.
- Added a "Save Image" button to the font controls in the rendered output tab.
- Implemented JavaScript logic (`saveOutputAsImage`) in the rendered output tab to:
    - Explicitly re-render KaTeX on the target element.
    - Introduce a short delay to ensure all rendering (especially KaTeX and external images) is complete.
    - Use html2canvas to capture the `body.markdown-body` content of the rendered output.
    - Trigger a download of the resulting PNG image, named `rendered_output.png`.
- The button is integrated into the collapsible font control panel.
- Removed old code related to a previous implementation attempt on the main page.

The functionality was tested to ensure Markdown, LaTeX, and embedded images are correctly captured in the downloaded image.