### PR TITLE
feat: Add 'Save as Image' feature to rendered Markdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,6 +237,7 @@ $$
             <button id="increaseFontBtn" title="Increase font size" style="padding: 4px 8px; cursor: pointer; border: 1px solid #ccc; background-color: #fff; color: black; border-radius: 3px;">+</button>
             <button id="resetFontBtn" title="Reset font size" style="padding: 4px 8px; cursor: pointer; margin-left: 5px; border: 1px solid #ccc; background-color: #fff; color: black; border-radius: 3px;">Reset</button>
             <button id="toggleThemeBtn" title="Toggle theme" style="padding: 4px 8px; cursor: pointer; margin-left: 5px; border: 1px solid #ccc; background-color: #fff; color: black; border-radius: 3px;">Theme</button>
+            <button id="saveAsImageBtn" title="Save as image" style="padding: 4px 8px; cursor: pointer; margin-left: 5px; border: 1px solid #ccc; background-color: #fff; color: black; border-radius: 3px;">Save Image</button>
         </div>
         `;
 
@@ -274,6 +275,67 @@ $$
             resetButton.addEventListener('click', () => applyFontSize(DEFAULT_PERCENT));
             
             applyFontSize(currentPercent); // Apply initial font size
+        }
+        `;
+
+        const SAVE_AS_IMAGE_LOGIC = `
+        function setupSaveAsImage() {
+            const saveButton = document.getElementById('saveAsImageBtn');
+            const fontControls = document.getElementById('font-controls');
+            const bodyToCapture = document.querySelector('body.markdown-body');
+
+            if (!saveButton || !fontControls || !bodyToCapture) {
+                console.error('Save as Image button, font controls, or body element not found.');
+                if (saveButton) saveButton.style.display = 'none'; // Hide button if it can't function
+                return;
+            }
+
+            saveButton.addEventListener('click', () => {
+                if (typeof html2canvas === 'undefined') {
+                    console.error('html2canvas is not loaded.');
+                    alert('Error: html2canvas library is not available. Cannot save image.');
+                    return;
+                }
+
+                // Temporarily hide font controls
+                fontControls.style.display = 'none';
+
+                html2canvas(bodyToCapture, {
+                    logging: false, // Optionally enable for debugging
+                    useCORS: true, // If you have external images/resources
+                    onclone: (clonedDoc) => {
+                        // Ensure the body of the cloned document doesn't have excessive padding if it was meant for the controls
+                        // This is a good place to make minor adjustments to the cloned document before rendering, if needed.
+                        // For instance, if the padding-top was specifically for the fixed controls, remove or reduce it.
+                        const clonedBody = clonedDoc.querySelector('body.markdown-body');
+                        if (clonedBody) {
+                            // Reduce the top padding for the screenshot since controls are hidden
+                            clonedBody.style.paddingTop = '20px';
+                        }
+                    }
+                }).then(canvas => {
+                    // Unhide font controls
+                    fontControls.style.display = 'flex'; // Assuming it was flex
+
+                    const randomPart = Math.random().toString(36).substring(2, 10);
+                    const timestamp = new Date().getTime();
+                    const filename = \`markdown-render-\${timestamp}-\${randomPart}.png\`;
+
+                    const image = canvas.toDataURL('image/png');
+                    const link = document.createElement('a');
+                    link.href = image;
+                    link.download = filename;
+                    document.body.appendChild(link);
+                    link.click();
+                    document.body.removeChild(link);
+
+                }).catch(err => {
+                    // Ensure font controls are visible even if there's an error
+                    fontControls.style.display = 'flex';
+                    console.error('Error capturing image with html2canvas:', err);
+                    alert('Sorry, an error occurred while trying to save the image.');
+                });
+            });
         }
         `;
 
@@ -430,12 +492,14 @@ $$
                         <title>${pageTitle}</title>
                         <link rel="stylesheet" href="${GITHUB_MARKDOWN_CSS_LINK}">
                         <link rel="stylesheet" href="${KATEX_CSS_LINK}">
+                        <script defer src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"><\/script>
                         ${RENDERED_PAGE_BODY_STYLE}
                         <script>
                             ${KATEX_INIT_LOGIC}
                             ${FONT_SIZE_CONTROL_SCRIPT_LOGIC}
                             ${THEME_CONTROL_SCRIPT_LOGIC}
                             ${COLLAPSIBLE_CONTROLS_SCRIPT_LOGIC}
+                            ${SAVE_AS_IMAGE_LOGIC}
                         <\/script>
                         <script defer src="${KATEX_JS_LINK}"><\/script>
                         <script defer src="${KATEX_AUTORENDER_JS_LINK}" onload="initKatexAutoRender()"><\/script>
@@ -448,6 +512,7 @@ $$
                                 setupFontSizeControls();
                                 setupThemeControls();
                                 setupCollapsibleControls();
+                                setupSaveAsImage(); // Add this line
                                 // initKatexAutoRender is called by KaTeX auto-render script's onload.
                             });
                         <\/script>


### PR DESCRIPTION
This commit introduces a new functionality allowing you to save the rendered Markdown content as a PNG image.

Key changes:
- Added a 'Save Image' button to the font controls panel in the rendered output tab.
- Integrated the html2canvas library (via CDN) to capture the rendered Markdown content.
- Implemented JavaScript logic (`setupSaveAsImage`) that:
    - Hides the font controls panel before capturing.
    - Captures the `body.markdown-body` element.
    - Adjusts the `padding-top` of the cloned document during capture to avoid excessive whitespace.
    - Restores the font controls panel after capture or on error.
    - Generates a random filename (e.g., markdown-render-1678886400000-random.png).
    - Triggers a browser download for the generated PNG image.
- Ensured the new functionality is initialized when the rendered content page loads.