### PR TITLE
feat: Enhance font controls and apply theming

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,6 +207,46 @@ $$
                color: #FFFFFF;
                border-bottom-color: #555555;
             }
+
+            /* Font Controls Styling */
+            .fc-panel {
+                background: rgba(240,240,240,0.95); /* Default light theme background */
+                /* border: 1px solid #ccc; /* Optional: if panel needs a border */
+            }
+            .fc-button {
+                padding: 4px 8px; /* Consolidate padding if consistent */
+                cursor: pointer;
+                background-color: #fff;
+                color: black;
+                border: 1px solid #ccc;
+                border-radius: 3px;
+            }
+            .fc-button:hover {
+                background-color: #eee; /* Light theme hover */
+            }
+            .fc-display {
+                color: black; /* Light theme text color */
+                padding: 0 5px; /* from original style */
+                min-width: 40px; /* from original style */
+                text-align: center; /* from original style */
+            }
+
+            /* Dark Theme Font Controls */
+            body.markdown-body.dark-theme .fc-panel {
+                background: rgba(50,50,50,0.95); /* Dark theme background */
+                /* border: 1px solid #555; /* Optional: dark theme border */
+            }
+            body.markdown-body.dark-theme .fc-button {
+                background-color: #333;
+                color: #eee;
+                border: 1px solid #555;
+            }
+            body.markdown-body.dark-theme .fc-button:hover {
+                background-color: #444; /* Dark theme hover */
+            }
+            body.markdown-body.dark-theme .fc-display {
+                color: #eee; /* Dark theme text color */
+            }
         </style>
         `;
 
@@ -230,13 +270,14 @@ $$
         `;
 
         const FONT_CONTROL_UI_HTML = `
-        <div id="font-controls" style="position: fixed; top: 10px; right: 10px; background: rgba(240,240,240,0.95); padding: 8px; border-radius: 5px; box-shadow: 0 2px 5px rgba(0,0,0,0.2); z-index: 1000; display: flex; align-items: center; gap: 5px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; font-size: 13px;">
-            <button id="toggleCollapseBtn" title="Toggle font controls" style="padding: 4px 8px; cursor: pointer; border: 1px solid #ccc; background-color: #fff; color: black; border-radius: 3px; margin-right: 5px;">Toggle</button>
-            <button id="decreaseFontBtn" title="Decrease font size" style="padding: 4px 8px; cursor: pointer; border: 1px solid #ccc; background-color: #fff; color: black; border-radius: 3px;">-</button>
-            <span id="currentFontSizeDisplay" style="min-width: 40px; text-align: center; padding: 0 5px; color: black;">100%</span>
-            <button id="increaseFontBtn" title="Increase font size" style="padding: 4px 8px; cursor: pointer; border: 1px solid #ccc; background-color: #fff; color: black; border-radius: 3px;">+</button>
-            <button id="resetFontBtn" title="Reset font size" style="padding: 4px 8px; cursor: pointer; margin-left: 5px; border: 1px solid #ccc; background-color: #fff; color: black; border-radius: 3px;">Reset</button>
-            <button id="toggleThemeBtn" title="Toggle theme" style="padding: 4px 8px; cursor: pointer; margin-left: 5px; border: 1px solid #ccc; background-color: #fff; color: black; border-radius: 3px;">Theme</button>
+        <div id="font-controls" class="fc-panel" style="position: fixed; top: 10px; right: 10px; padding: 8px; border-radius: 5px; box-shadow: 0 2px 5px rgba(0,0,0,0.2); z-index: 1000; display: flex; align-items: center; gap: 5px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; font-size: 13px;">
+            <button id="toggleCollapseBtn" title="Toggle font controls" class="fc-button" style="padding: 4px 8px; cursor: pointer; margin-right: 5px;">Toggle</button>
+            <button id="decreaseFontBtn" title="Decrease font size" class="fc-button" style="padding: 4px 8px; cursor: pointer;">-</button>
+            <span id="currentFontSizeDisplay" class="fc-display" style="min-width: 40px; text-align: center; padding: 0 5px;">100%</span>
+            <button id="increaseFontBtn" title="Increase font size" class="fc-button" style="padding: 4px 8px; cursor: pointer;">+</button>
+            <button id="resetFontBtn" title="Reset font size" class="fc-button" style="padding: 4px 8px; cursor: pointer; margin-left: 5px;">Reset</button>
+            <button id="toggleThemeBtn" title="Toggle theme" class="fc-button" style="padding: 4px 8px; cursor: pointer; margin-left: 5px;">Theme</button>
+            <button id="saveAsImageBtn" title="Save as image" class="fc-button" style="padding: 4px 8px; cursor: pointer; margin-left: 5px;">Save Image</button>
         </div>
         `;
 
@@ -277,42 +318,120 @@ $$
         }
         `;
 
+        const SAVE_AS_IMAGE_LOGIC = `
+        function setupSaveAsImage() {
+            const saveButton = document.getElementById('saveAsImageBtn');
+            const fontControls = document.getElementById('font-controls');
+            const bodyToCapture = document.querySelector('body.markdown-body');
+
+            if (!saveButton || !fontControls || !bodyToCapture) {
+                console.error('Save as Image button, font controls, or body element not found.');
+                if (saveButton) saveButton.style.display = 'none'; // Hide button if it can't function
+                return;
+            }
+
+            saveButton.addEventListener('click', () => {
+                if (typeof html2canvas === 'undefined') {
+                    console.error('html2canvas is not loaded.');
+                    alert('Error: html2canvas library is not available. Cannot save image.');
+                    return;
+                }
+
+                // Temporarily hide font controls
+                fontControls.style.display = 'none';
+
+                html2canvas(bodyToCapture, {
+                    logging: false, // Optionally enable for debugging
+                    useCORS: true, // If you have external images/resources
+                    onclone: (clonedDoc) => {
+                        // Ensure the body of the cloned document doesn't have excessive padding if it was meant for the controls
+                        // This is a good place to make minor adjustments to the cloned document before rendering, if needed.
+                        // For instance, if the padding-top was specifically for the fixed controls, remove or reduce it.
+                        const clonedBody = clonedDoc.querySelector('body.markdown-body');
+                        if (clonedBody) {
+                            // Reduce the top padding for the screenshot since controls are hidden
+                            clonedBody.style.paddingTop = '20px';
+                        }
+                    }
+                }).then(canvas => {
+                    // Unhide font controls
+                    fontControls.style.display = 'flex'; // Assuming it was flex
+
+                    const randomPart = Math.random().toString(36).substring(2, 10);
+                    const timestamp = new Date().getTime();
+                    const filename = \`markdown-render-\${timestamp}-\${randomPart}.png\`;
+
+                    const image = canvas.toDataURL('image/png');
+                    const link = document.createElement('a');
+                    link.href = image;
+                    link.download = filename;
+                    document.body.appendChild(link);
+                    link.click();
+                    document.body.removeChild(link);
+
+                }).catch(err => {
+                    // Ensure font controls are visible even if there's an error
+                    fontControls.style.display = 'flex';
+                    console.error('Error capturing image with html2canvas:', err);
+                    alert('Sorry, an error occurred while trying to save the image.');
+                });
+            });
+        }
+        `;
+
         const COLLAPSIBLE_CONTROLS_SCRIPT_LOGIC = `
         function setupCollapsibleControls() {
             const toggleButton = document.getElementById('toggleCollapseBtn');
-            const controlsToToggle = [
-                document.getElementById('decreaseFontBtn'),
-                document.getElementById('currentFontSizeDisplay'),
-                document.getElementById('increaseFontBtn'),
-                document.getElementById('resetFontBtn'),
-                document.getElementById('toggleThemeBtn')
-            ].filter(el => el !== null); // Filter out nulls if some elements are not found
+            // Explicitly get all buttons that are part of the collapsible set
+            const decreaseFontBtn = document.getElementById('decreaseFontBtn');
+            const currentFontSizeDisplay = document.getElementById('currentFontSizeDisplay');
+            const increaseFontBtn = document.getElementById('increaseFontBtn');
+            const resetFontBtn = document.getElementById('resetFontBtn');
+            const toggleThemeBtn = document.getElementById('toggleThemeBtn');
+            const saveImageBtn = document.getElementById('saveAsImageBtn');
 
-            if (!toggleButton || controlsToToggle.length < 4) { // Check if main button and at least some controls exist
-                console.error("Collapsible control elements not found. Ensure IDs are correct ('toggleCollapseBtn', etc.) and DOM is ready.");
-                if (toggleButton) toggleButton.style.display = 'none'; // Hide toggle if other controls are missing
-                return;
+            const controlsToToggle = [
+                decreaseFontBtn,
+                currentFontSizeDisplay,
+                increaseFontBtn,
+                resetFontBtn,
+                toggleThemeBtn,
+                saveImageBtn
+            ].filter(el => el !== null); // Filter out any that might be missing
+
+            // Adjusted check: ensure toggle button and a reasonable number of controls are found
+            if (!toggleButton || controlsToToggle.length < 5) {
+                console.warn("Collapsible control elements (expected at least 5 including Save Image) not fully found. Some controls may not toggle.");
+                if (toggleButton && controlsToToggle.length === 0) { // If only toggle button found, but nothing to toggle
+                     toggleButton.style.display = 'none'; // Hide toggle if other controls are missing
+                }
+                // Not returning here, allow it to proceed with what it found
             }
 
             const LS_COLLAPSED_KEY = 'fontControlsCollapsed';
 
-            function applyCollapsedState(collapsed) {
-                const isCurrentlyCollapsed = typeof collapsed === 'boolean' ? collapsed : JSON.parse(localStorage.getItem(LS_COLLAPSED_KEY) || 'true');
+            function applyCollapsedState(collapsedArgument) { // Renamed 'collapsed' to avoid conflict
+                const isCurrentlyCollapsed = typeof collapsedArgument === 'boolean' ? collapsedArgument : JSON.parse(localStorage.getItem(LS_COLLAPSED_KEY) || 'true');
 
                 controlsToToggle.forEach(control => {
-                    control.style.display = isCurrentlyCollapsed ? 'none' : ''; // Use '' to revert to default/CSS display
+                    // No need for extra null check, filter(el => el !== null) already handled it.
+                    control.style.display = isCurrentlyCollapsed ? 'none' : '';
                 });
-                toggleButton.textContent = isCurrentlyCollapsed ? 'Expand Controls' : 'Collapse Controls';
+                if (toggleButton) { // Check if toggleButton itself exists
+                    toggleButton.textContent = isCurrentlyCollapsed ? 'Expand Controls' : 'Collapse Controls';
+                }
                 localStorage.setItem(LS_COLLAPSED_KEY, JSON.stringify(isCurrentlyCollapsed));
             }
 
-            toggleButton.addEventListener('click', () => {
-                const currentState = JSON.parse(localStorage.getItem(LS_COLLAPSED_KEY) || 'true');
-                applyCollapsedState(!currentState);
-            });
+            if (toggleButton) { // Only add listener if toggle button exists
+                toggleButton.addEventListener('click', () => {
+                    const currentState = JSON.parse(localStorage.getItem(LS_COLLAPSED_KEY) || 'true');
+                    applyCollapsedState(!currentState);
+                });
+            }
 
             // Initial state application
-            applyCollapsedState(); // Applies based on localStorage or default true
+            applyCollapsedState();
         }
         `;
 
@@ -430,12 +549,14 @@ $$
                         <title>${pageTitle}</title>
                         <link rel="stylesheet" href="${GITHUB_MARKDOWN_CSS_LINK}">
                         <link rel="stylesheet" href="${KATEX_CSS_LINK}">
+                        <script defer src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"><\/script>
                         ${RENDERED_PAGE_BODY_STYLE}
                         <script>
                             ${KATEX_INIT_LOGIC}
                             ${FONT_SIZE_CONTROL_SCRIPT_LOGIC}
                             ${THEME_CONTROL_SCRIPT_LOGIC}
                             ${COLLAPSIBLE_CONTROLS_SCRIPT_LOGIC}
+                            ${SAVE_AS_IMAGE_LOGIC}
                         <\/script>
                         <script defer src="${KATEX_JS_LINK}"><\/script>
                         <script defer src="${KATEX_AUTORENDER_JS_LINK}" onload="initKatexAutoRender()"><\/script>
@@ -448,6 +569,7 @@ $$
                                 setupFontSizeControls();
                                 setupThemeControls();
                                 setupCollapsibleControls();
+                                setupSaveAsImage(); // Add this line
                                 // initKatexAutoRender is called by KaTeX auto-render script's onload.
                             });
                         <\/script>


### PR DESCRIPTION
This commit addresses your feedback to improve the font controls panel:

1.  **Default Collapsed State**: The font controls panel in the rendered Markdown view now defaults to a collapsed state. The "Save Image" button is also hidden when the panel is collapsed and becomes visible only when expanded.

2.  **Theming for Font Controls**: The font controls panel (including buttons and text display) now respects the application's selected theme (light/dark). Inline styles were replaced with CSS classes, and theme-specific rules were added to ensure visual consistency.

These changes improve your experience by providing a cleaner default view and better visual integration of the font controls with the application's theme.