### PR TITLE
Fix: Improve table border visibility in light mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@ $$
             }
             body.markdown-body.light-theme th,
             body.markdown-body.light-theme td {
-               border-color: #dddddd;
+               border: 1px solid #cccccc; /* Applied a more complete border definition */
             }
             body.markdown-body.light-theme code:not([class*="language-"]),
             body.markdown-body.light-theme pre {


### PR DESCRIPTION
This commit addresses an issue where Markdown tables appeared broken or had indistinct borders in light mode. The previous light theme style for tables only set the `border-color`, relying on `github-markdown.min.css` for the border width and style. This could lead to borders being too faint or not rendering as expected against light backgrounds.

The fix involves updating the CSS rule for table headers (`th`) and table cells (`td`) within the `RENDERED_PAGE_BODY_STYLE` for the light theme:

- Changed from: `border-color: #dddddd;`
- Changed to: `border: 1px solid #cccccc;`

This provides a more complete and explicit border definition, ensuring that table cell borders are consistently 1px wide, solid, and use a more visible shade of gray (`#cccccc`) in the light theme. This change improves the clarity and visual structure of tables in light mode.