### PR TITLE
Fix: Resolve tables appearing black in light mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -453,10 +453,12 @@ $$
                 if (theme === 'dark') {
                     body.classList.add(DARK_THEME_CLASS);
                     body.classList.remove(LIGHT_THEME_CLASS);
+                    body.setAttribute('data-theme', 'dark'); // Add this line
                     toggleThemeButton.textContent = 'Light Theme';
                 } else { // Light theme
                     body.classList.add(LIGHT_THEME_CLASS);
                     body.classList.remove(DARK_THEME_CLASS);
+                    body.setAttribute('data-theme', 'light'); // Add this line
                     toggleThemeButton.textContent = 'Dark Theme';
                 }
                 localStorage.setItem(LS_THEME_KEY, theme);


### PR DESCRIPTION
This commit addresses a critical issue where Markdown tables were rendering with black backgrounds and borders in light mode, making the black text invisible.

The root cause was that the `github-markdown.min.css` library relies on either the `prefers-color-scheme` media query or a `data-theme` attribute on an HTML element to apply its theme-specific variables (including table backgrounds and default border colors). The previous JavaScript theme switching logic only added/removed local theme classes (`.light-theme`/`.dark-theme`) and did not set the `data-theme` attribute. Consequently, if `prefers-color-scheme` was dark, the library could apply its dark theme variables for table backgrounds even when our local light theme class was active for text color.

The fix involves updating the `applyTheme` function in `THEME_CONTROL_SCRIPT_LOGIC` to set the `data-theme` attribute (e.g., `body.setAttribute('data-theme', 'light')`) on the `body.markdown-body` element in addition to managing the CSS classes.

This ensures that `github-markdown.min.css` correctly uses its light theme variables (white/light-gray table backgrounds, light gray borders) when the light theme is selected, and dark theme variables when the dark theme is selected. Our local CSS continues to manage overall theme text colors and provide minor, compatible adjustments to border colors.