### PR TITLE
Fix: Correct table styling in light and dark modes

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,9 @@ $$
             }
             body.markdown-body th,
             body.markdown-body td {
-               border-color: #dddddd;
+               border-color: #dddddd; /* Existing rule */
+               background-color: #FFFFFF; /* New rule for light mode background */
+               color: #000000; /* New rule for light mode text color */
             }
             body.markdown-body code:not([class*="language-"]),
             body.markdown-body pre {
@@ -191,7 +193,9 @@ $$
             }
             body.markdown-body.dark-theme th,
             body.markdown-body.dark-theme td {
-               border-color: #555555;
+               border-color: #555555; /* Existing rule */
+               background-color: #1C1C1C; /* New rule for dark mode background */
+               color: #E0E0E0; /* New rule for dark mode text color */
             }
             body.markdown-body.dark-theme code:not([class*="language-"]),
             body.markdown-body.dark-theme pre {


### PR DESCRIPTION
The tables were previously unusable in light mode due to black text on a black background. This was caused by styles from the external github-markdown.css interfering with the local theme.

This commit addresses the issue by:
1. Adding explicit `background-color` and `color` properties for table cells (`th` and `td`) in the light theme to ensure proper contrast.
2. Adding explicit `background-color` and `color` properties for table cells in the dark theme to ensure they are not overridden by the light theme styles or the external stylesheet, thus maintaining their distinct appearance.

Table cells now render correctly with appropriate text and background colors in both light and dark themes.