### PR TITLE
Prevent long-word overflow in rendered markdown output

### DIFF
--- a/js/rendered-page-builder.js
+++ b/js/rendered-page-builder.js
@@ -65,6 +65,10 @@ class RenderedPageBuilder {
                 background-color: #ffffff;
                 color: #24292e;
             }
+            body.markdown-body #content-container {
+                overflow-wrap: anywhere;
+                word-break: break-word;
+            }
             body.markdown-body a {
                 color: #0366d6;
                 text-decoration: none;
@@ -125,6 +129,12 @@ class RenderedPageBuilder {
                 overflow: auto;
                 padding: 16px;
                 margin: 16px 0;
+            }
+            body.markdown-body pre,
+            body.markdown-body code,
+            body.markdown-body #raw-markdown {
+                overflow-wrap: normal;
+                word-break: normal;
             }
             body.markdown-body pre code {
                 background-color: transparent;


### PR DESCRIPTION
### Motivation
- Very long unbroken strings were expanding the rendered output container and breaking page layout when content contained long words without natural break points.
- The goal is to ensure long words wrap or break inside the rendered output while preserving readable behavior for code blocks and raw markdown.

### Description
- Added CSS rules in `js/rendered-page-builder.js` that scope long-word wrapping to the rendered content by targeting `#content-container` with `overflow-wrap: anywhere` and `word-break: break-word`.
- Explicitly reset wrapping for code and raw views by setting `overflow-wrap: normal` and `word-break: normal` on `pre`, `code`, and `#raw-markdown` to avoid breaking monospace/code formatting.
- Change is limited to the inline styles emitted by `RenderedPageBuilder` so behavior only affects the rendered output tab.

### Testing
- Ran `git diff --check` and it passed without issues.
- Ran `node --check js/rendered-page-builder.js` to validate the modified JS file and it passed without errors.
- Attempted a browser-based visual test with Playwright to capture a screenshot, but the automated browser could not reach the local server (`ERR_EMPTY_RESPONSE`) so the screenshot step failed and could not be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699af3d202708328b42500354276f092)